### PR TITLE
Updates all GitHub Actions `setup-java` to v5

### DIFF
--- a/.github/workflows/build-mupdf-java.yml
+++ b/.github/workflows/build-mupdf-java.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set up JDK ${{ matrix.java }}
         if: runner.os != 'linux'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Set up JDK ${{ matrix.java }}
         if: runner.os != 'linux'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'


### PR DESCRIPTION
Similar to https://github.com/lectureStudio/lectureStudio/pull/1054, this PR updates all `setup-java` actions to the recently released v5.