### PR TITLE
Updates all GitHub Actions `upload-artifact` to v5

### DIFF
--- a/.github/workflows/build-mupdf-java/build-linux/action.yml
+++ b/.github/workflows/build-mupdf-java/build-linux/action.yml
@@ -40,7 +40,7 @@ runs:
         mv "$file" libmupdf_java.so
 
     - name: Upload JNI library
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: mupdf-java-${{ inputs.platform-name }}
         path: mupdf/build/java/release/libmupdf_java.so

--- a/.github/workflows/build-mupdf-java/build-macos/action.yml
+++ b/.github/workflows/build-mupdf-java/build-macos/action.yml
@@ -29,7 +29,7 @@ runs:
         mv "$file" libmupdf_java.dylib
 
     - name: Upload JNI library
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: mupdf-java-${{ inputs.platform-name }}
         path: mupdf/build/java/release/libmupdf_java.dylib

--- a/.github/workflows/build-mupdf-java/build-windows/action.yml
+++ b/.github/workflows/build-mupdf-java/build-windows/action.yml
@@ -44,7 +44,7 @@ runs:
         find . -name "*.dll" -exec mv {} mupdf_java.dll \;
 
     - name: Upload JNI library
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: mupdf-java-${{ inputs.platform-name }}
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         run: mvn install
 
       - name: Upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Build-${{ runner.os }}-${{ runner.arch }}
           path: |


### PR DESCRIPTION
Similar to https://github.com/lectureStudio/lectureStudio/pull/1055, this PR updates all `upload-artifact` actions to the recently released v5.